### PR TITLE
create Gradle JVM component model project

### DIFF
--- a/g3-java-model/build.gradle
+++ b/g3-java-model/build.gradle
@@ -1,0 +1,37 @@
+plugins {
+    id 'jvm-component'
+    id 'java-lang'
+}
+
+ext {
+    modPrefix = 'com.bsf'
+}
+
+model {
+    components {
+        "${modPrefix}.basic"(JvmLibrarySpec) {
+            targetPlatform 'java6'
+        }
+        "${modPrefix}.functions"(JvmLibrarySpec) {
+            targetPlatform 'java6'
+            sources {
+                java {
+                    dependencies {
+                        library "${modPrefix}.basic"
+                    }
+                }
+            }
+        }
+        "${modPrefix}.data"(JvmLibrarySpec) {
+            targetPlatform 'java6'
+            sources {
+                java {
+                    dependencies {
+                        library "${modPrefix}.basic"
+                        library "${modPrefix}.functions"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/g3-java-model/gradle.properties
+++ b/g3-java-model/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=true

--- a/g3-java-model/gradle/wrapper/gradle-wrapper.properties
+++ b/g3-java-model/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,6 @@
+#Fri Nov 13 20:21:01 JST 2015
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.8-bin.zip

--- a/g3-java-model/gradlew
+++ b/g3-java-model/gradlew
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+
+##############################################################################
+##
+##  Gradle start up script for UN*X
+##
+##############################################################################
+
+# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+DEFAULT_JVM_OPTS=""
+
+APP_NAME="Gradle"
+APP_BASE_NAME=`basename "$0"`
+
+# Use the maximum available, or set MAX_FD != -1 to use that value.
+MAX_FD="maximum"
+
+warn ( ) {
+    echo "$*"
+}
+
+die ( ) {
+    echo
+    echo "$*"
+    echo
+    exit 1
+}
+
+# OS specific support (must be 'true' or 'false').
+cygwin=false
+msys=false
+darwin=false
+case "`uname`" in
+  CYGWIN* )
+    cygwin=true
+    ;;
+  Darwin* )
+    darwin=true
+    ;;
+  MINGW* )
+    msys=true
+    ;;
+esac
+
+# Attempt to set APP_HOME
+# Resolve links: $0 may be a link
+PRG="$0"
+# Need this for relative symlinks.
+while [ -h "$PRG" ] ; do
+    ls=`ls -ld "$PRG"`
+    link=`expr "$ls" : '.*-> \(.*\)$'`
+    if expr "$link" : '/.*' > /dev/null; then
+        PRG="$link"
+    else
+        PRG=`dirname "$PRG"`"/$link"
+    fi
+done
+SAVED="`pwd`"
+cd "`dirname \"$PRG\"`/" >/dev/null
+APP_HOME="`pwd -P`"
+cd "$SAVED" >/dev/null
+
+CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
+
+# Determine the Java command to use to start the JVM.
+if [ -n "$JAVA_HOME" ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+        # IBM's JDK on AIX uses strange locations for the executables
+        JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+        JAVACMD="$JAVA_HOME/bin/java"
+    fi
+    if [ ! -x "$JAVACMD" ] ; then
+        die "ERROR: JAVA_HOME is set to an invalid directory: $JAVA_HOME
+
+Please set the JAVA_HOME variable in your environment to match the
+location of your Java installation."
+    fi
+else
+    JAVACMD="java"
+    which java >/dev/null 2>&1 || die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+
+Please set the JAVA_HOME variable in your environment to match the
+location of your Java installation."
+fi
+
+# Increase the maximum file descriptors if we can.
+if [ "$cygwin" = "false" -a "$darwin" = "false" ] ; then
+    MAX_FD_LIMIT=`ulimit -H -n`
+    if [ $? -eq 0 ] ; then
+        if [ "$MAX_FD" = "maximum" -o "$MAX_FD" = "max" ] ; then
+            MAX_FD="$MAX_FD_LIMIT"
+        fi
+        ulimit -n $MAX_FD
+        if [ $? -ne 0 ] ; then
+            warn "Could not set maximum file descriptor limit: $MAX_FD"
+        fi
+    else
+        warn "Could not query maximum file descriptor limit: $MAX_FD_LIMIT"
+    fi
+fi
+
+# For Darwin, add options to specify how the application appears in the dock
+if $darwin; then
+    GRADLE_OPTS="$GRADLE_OPTS \"-Xdock:name=$APP_NAME\" \"-Xdock:icon=$APP_HOME/media/gradle.icns\""
+fi
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin ; then
+    APP_HOME=`cygpath --path --mixed "$APP_HOME"`
+    CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
+    JAVACMD=`cygpath --unix "$JAVACMD"`
+
+    # We build the pattern for arguments to be converted via cygpath
+    ROOTDIRSRAW=`find -L / -maxdepth 1 -mindepth 1 -type d 2>/dev/null`
+    SEP=""
+    for dir in $ROOTDIRSRAW ; do
+        ROOTDIRS="$ROOTDIRS$SEP$dir"
+        SEP="|"
+    done
+    OURCYGPATTERN="(^($ROOTDIRS))"
+    # Add a user-defined pattern to the cygpath arguments
+    if [ "$GRADLE_CYGPATTERN" != "" ] ; then
+        OURCYGPATTERN="$OURCYGPATTERN|($GRADLE_CYGPATTERN)"
+    fi
+    # Now convert the arguments - kludge to limit ourselves to /bin/sh
+    i=0
+    for arg in "$@" ; do
+        CHECK=`echo "$arg"|egrep -c "$OURCYGPATTERN" -`
+        CHECK2=`echo "$arg"|egrep -c "^-"`                                 ### Determine if an option
+
+        if [ $CHECK -ne 0 ] && [ $CHECK2 -eq 0 ] ; then                    ### Added a condition
+            eval `echo args$i`=`cygpath --path --ignore --mixed "$arg"`
+        else
+            eval `echo args$i`="\"$arg\""
+        fi
+        i=$((i+1))
+    done
+    case $i in
+        (0) set -- ;;
+        (1) set -- "$args0" ;;
+        (2) set -- "$args0" "$args1" ;;
+        (3) set -- "$args0" "$args1" "$args2" ;;
+        (4) set -- "$args0" "$args1" "$args2" "$args3" ;;
+        (5) set -- "$args0" "$args1" "$args2" "$args3" "$args4" ;;
+        (6) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" ;;
+        (7) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" ;;
+        (8) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" ;;
+        (9) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" "$args8" ;;
+    esac
+fi
+
+# Split up the JVM_OPTS And GRADLE_OPTS values into an array, following the shell quoting and substitution rules
+function splitJvmOpts() {
+    JVM_OPTS=("$@")
+}
+eval splitJvmOpts $DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS
+JVM_OPTS[${#JVM_OPTS[*]}]="-Dorg.gradle.appname=$APP_BASE_NAME"
+
+exec "$JAVACMD" "${JVM_OPTS[@]}" -classpath "$CLASSPATH" org.gradle.wrapper.GradleWrapperMain "$@"

--- a/g3-java-model/gradlew.bat
+++ b/g3-java-model/gradlew.bat
@@ -1,0 +1,90 @@
+@if "%DEBUG%" == "" @echo off
+@rem ##########################################################################
+@rem
+@rem  Gradle startup script for Windows
+@rem
+@rem ##########################################################################
+
+@rem Set local scope for the variables with windows NT shell
+if "%OS%"=="Windows_NT" setlocal
+
+@rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+set DEFAULT_JVM_OPTS=
+
+set DIRNAME=%~dp0
+if "%DIRNAME%" == "" set DIRNAME=.
+set APP_BASE_NAME=%~n0
+set APP_HOME=%DIRNAME%
+
+@rem Find java.exe
+if defined JAVA_HOME goto findJavaFromJavaHome
+
+set JAVA_EXE=java.exe
+%JAVA_EXE% -version >NUL 2>&1
+if "%ERRORLEVEL%" == "0" goto init
+
+echo.
+echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:findJavaFromJavaHome
+set JAVA_HOME=%JAVA_HOME:"=%
+set JAVA_EXE=%JAVA_HOME%/bin/java.exe
+
+if exist "%JAVA_EXE%" goto init
+
+echo.
+echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:init
+@rem Get command-line arguments, handling Windowz variants
+
+if not "%OS%" == "Windows_NT" goto win9xME_args
+if "%@eval[2+2]" == "4" goto 4NT_args
+
+:win9xME_args
+@rem Slurp the command line arguments.
+set CMD_LINE_ARGS=
+set _SKIP=2
+
+:win9xME_args_slurp
+if "x%~1" == "x" goto execute
+
+set CMD_LINE_ARGS=%*
+goto execute
+
+:4NT_args
+@rem Get arguments from the 4NT Shell from JP Software
+set CMD_LINE_ARGS=%$
+
+:execute
+@rem Setup the command line
+
+set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
+
+@rem Execute Gradle
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %CMD_LINE_ARGS%
+
+:end
+@rem End local scope for the variables with windows NT shell
+if "%ERRORLEVEL%"=="0" goto mainEnd
+
+:fail
+rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
+rem the _cmd.exe /c_ return code!
+if  not "" == "%GRADLE_EXIT_CONSOLE%" exit 1
+exit /b 1
+
+:mainEnd
+if "%OS%"=="Windows_NT" endlocal
+
+:omega

--- a/g3-java-model/settings.gradle
+++ b/g3-java-model/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'g3-java-model'

--- a/g3-java-model/src/com.bsf.basic/java/com/bsf/basic/EvaluationException.java
+++ b/g3-java-model/src/com.bsf.basic/java/com/bsf/basic/EvaluationException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2015 Shinya Mochida
+ *
+ * Licensed under the Apache License,Version2.0(the"License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,software
+ * Distributed under the License is distributed on an"AS IS"BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.bsf.basic;
+
+/**
+ * An exception for the method which doesn't accept {@code null} argument.
+ */
+public final class EvaluationException extends RuntimeException {
+
+    public EvaluationException(String message) {
+        super(message);
+    }
+}

--- a/g3-java-model/src/com.bsf.basic/java/com/bsf/basic/ExecutingException.java
+++ b/g3-java-model/src/com.bsf.basic/java/com/bsf/basic/ExecutingException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2015 Shinya Mochida
+ *
+ * Licensed under the Apache License,Version2.0(the"License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,software
+ * Distributed under the License is distributed on an"AS IS"BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.bsf.basic;
+
+public class ExecutingException extends RuntimeException {
+    public ExecutingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ExecutingException(String message) {
+        super(message);
+    }
+}

--- a/g3-java-model/src/com.bsf.data/java/com/bsf/data/ActingContext.java
+++ b/g3-java-model/src/com.bsf.data/java/com/bsf/data/ActingContext.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2015 Shinya Mochida
+ *
+ * Licensed under the Apache License,Version2.0(the"License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,software
+ * Distributed under the License is distributed on an"AS IS"BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.bsf.data;
+
+import com.bsf.basic.ExecutingException;
+
+public interface ActingContext {
+    void act() throws ExecutingException;
+}

--- a/g3-java-model/src/com.bsf.data/java/com/bsf/data/Either.java
+++ b/g3-java-model/src/com.bsf.data/java/com/bsf/data/Either.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2015 Shinya Mochida
+ *
+ * Licensed under the Apache License,Version2.0(the"License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,software
+ * Distributed under the License is distributed on an"AS IS"BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.bsf.data;
+
+import com.bsf.basic.EvaluationException;
+import com.bsf.basic.ExecutingException;
+
+import com.bsf.function.Actions.Action;
+import com.bsf.function.Conditions.Condition;
+import com.bsf.function.Functions.Function;
+import com.bsf.function.Lazies.Lazy;
+
+import com.bsf.data.EitherBase.Left;
+import com.bsf.data.EitherBase.Right;
+
+import java.util.NoSuchElementException;
+
+import static com.bsf.function.Verifications.actionShouldNotBeNull;
+import static com.bsf.function.Verifications.conditionShouldNotBeNull;
+import static com.bsf.function.Verifications.functionShouldNotBeNull;
+import static com.bsf.function.Verifications.lazyShouldNotBeNull;
+import static com.bsf.function.Verifications.shouldNotBeNull;
+
+public abstract class Either<L, R> {
+
+    // methods to test object
+
+    public boolean isLeft() {
+        return !isRight();
+    }
+
+    abstract public boolean isRight();
+
+    // methods to retrieve value
+
+    abstract public R get() throws NoSuchElementException;
+
+    public R or(R defaultValue) throws EvaluationException {
+        shouldNotBeNull(defaultValue, "Default value should be non null.");
+        return orInternal(defaultValue);
+    }
+
+    abstract protected R orInternal(R defaultValue);
+
+    public R or(Lazy<? extends R> lazy) throws EvaluationException, ExecutingException {
+        lazyShouldNotBeNull(lazy);
+        return orInternal(lazy);
+    }
+
+    abstract protected R orInternal(Lazy<? extends R> lazy) throws ExecutingException;
+
+    public R orThrow(Function<? super L, ? extends RuntimeException> fun)
+            throws RuntimeException {
+        functionShouldNotBeNull(fun);
+        return orThrowInternal(fun);
+    }
+
+    abstract protected R orThrowInternal(
+            Function<? super L, ? extends RuntimeException> fun)
+            throws ExecutingException;
+
+    // methods to mapping value to another value
+
+    public <E> Either<L, E> map(Function<? super R, ? extends E> fun)
+            throws EvaluationException, ExecutingException {
+        functionShouldNotBeNull(fun);
+        return mapInternal(fun);
+    }
+
+    abstract protected <E> Either<L, E> mapInternal(
+            Function<? super R, ? extends E> fun) throws ExecutingException;
+
+    public <E> Either<L, E> fmap(Function<? super R, ? extends Either<L, E>> fun)
+            throws EvaluationException, ExecutingException {
+        functionShouldNotBeNull(fun);
+        return fmapInternal(fun);
+    }
+
+    abstract protected <E> Either<L, E> fmapInternal(
+            Function<? super R, ? extends Either<L, E>> fun)
+            throws ExecutingException;
+
+    // methods to filter value
+
+    public Either<L, R> filter(Condition<? super R> cond)
+            throws EvaluationException, ExecutingException {
+        conditionShouldNotBeNull(cond);
+        return filterInternal(cond);
+    }
+
+    abstract protected Either<L, R> filterInternal(Condition<? super R> cond);
+
+    public Either<L, R> filter(Condition<? super R> cond, L left)
+            throws EvaluationException, ExecutingException {
+        conditionShouldNotBeNull(cond);
+        shouldNotBeNull(left, "Left cause should be non null.");
+        return filterInternal(cond, left);
+    }
+
+    abstract protected Either<L, R> filterInternal(
+            Condition<? super R> cond, L left)
+            throws ExecutingException;
+
+    // attach action
+
+    public static abstract class AttachAction<L> implements ActingContext {
+        public ActingContext onLeft(Action<? super L> forLeft)
+                throws EvaluationException {
+            actionShouldNotBeNull(forLeft);
+            return onLeftInternal(forLeft);
+        }
+
+        abstract protected ActingContext onLeftInternal(
+                Action<? super L> forLeft);
+    }
+
+    public AttachAction<L> onRight(Action<? super R> forRight)
+            throws EvaluationException {
+        actionShouldNotBeNull(forRight);
+        return onRightInternal(forRight);
+    }
+
+    abstract protected AttachAction<L> onRightInternal(
+            Action<? super R> forRight);
+
+    // constructor
+    public static <L, R> Either<L, R> left(L cause) throws EvaluationException {
+        shouldNotBeNull(cause, "Left cause should be non null.");
+        return new Left<L, R>(cause);
+    }
+
+    private static final Lazy<String> DEFAULT_LEFT = new Lazy<String>() {
+        @Override
+        public String get() throws ExecutingException {
+            return "The value doesn't matches to condition or is mapped to null or is f-mapped to nothing.";
+        }
+    };
+
+    public static <L, R> Either<L, R> right(R value, Lazy<L> left)
+            throws EvaluationException {
+        shouldNotBeNull(value, "Right value should be non null.");
+        lazyShouldNotBeNull(left);
+        return new Right<L, R>(value, left);
+    }
+
+    public static <R> RightBuilder<R> right(final R value)
+            throws EvaluationException {
+        shouldNotBeNull(value, "Right value should be non null.");
+        return new RightBuilder<R>() {
+            @Override
+            public Either<String, R> withLeft(final String left)
+                    throws EvaluationException {
+                shouldNotBeNull(left, "Left cause should be non null.");
+                return new Right<String, R>(value,
+                        new Lazy<String>() {
+                            @Override
+                            public String get() throws ExecutingException {
+                                return left;
+                            }
+                        });
+            }
+
+            @Override
+            public Either<String, R> build() {
+                return new Right<String, R>(value, DEFAULT_LEFT);
+            }
+        };
+    }
+
+    public interface RightBuilderWithLeft<L, R> {
+        Either<L, R> build();
+    }
+
+    public interface RightBuilder<R> extends RightBuilderWithLeft<String, R> {
+        Either<String, R> withLeft(String left) throws EvaluationException;
+    }
+}

--- a/g3-java-model/src/com.bsf.data/java/com/bsf/data/EitherBase.java
+++ b/g3-java-model/src/com.bsf.data/java/com/bsf/data/EitherBase.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2015 Shinya Mochida
+ *
+ * Licensed under the Apache License,Version2.0(the"License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,software
+ * Distributed under the License is distributed on an"AS IS"BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.bsf.data;
+
+import com.bsf.basic.ExecutingException;
+
+import com.bsf.function.Actions.Action;
+import com.bsf.function.Conditions.Condition;
+import com.bsf.function.Functions.Function;
+import com.bsf.function.Lazies.Lazy;
+
+import java.util.NoSuchElementException;
+
+import static com.bsf.function.Verifications.initializationNotSupported;
+import static com.bsf.function.Verifications.lazyShouldNotBeNull;
+import static com.bsf.function.Verifications.shouldNotBeNull;
+
+final class EitherBase {
+
+    private EitherBase() {
+        initializationNotSupported();
+    }
+
+    static class Left<L, R> extends Either<L, R> {
+
+        private final L cause;
+
+        Left(L cause) {
+            shouldNotBeNull(cause, "Left require cause.");
+            this.cause = cause;
+        }
+
+        @Override
+        public boolean isRight() {
+            return false;
+        }
+
+        @Override
+        public R get() throws NoSuchElementException {
+            throw new NoSuchElementException(cause.toString());
+        }
+
+        @Override
+        protected R orInternal(R defaultValue) {
+            return defaultValue;
+        }
+
+        @Override
+        protected R orInternal(Lazy<? extends R> lazy)
+                throws ExecutingException {
+            R result = lazy.get();
+            if (result == null) {
+                throw new ExecutingException("Default value should be non null.");
+            }
+            return result;
+        }
+
+        @Override
+        protected R orThrowInternal(Function<? super L, ? extends RuntimeException> fun)
+                throws RuntimeException {
+            RuntimeException e = fun.apply(cause);
+            if (e == null) {
+                throw new ExecutingException("Generated exception should be non null.");
+            }
+            throw e;
+        }
+
+        @Override
+        protected <E> Either<L, E> mapInternal(
+                Function<? super R, ? extends E> fun)
+                throws ExecutingException {
+            return new Left<L, E>(cause);
+        }
+
+        @Override
+        protected <E> Either<L, E> fmapInternal(
+                Function<? super R, ? extends Either<L, E>> fun)
+                throws ExecutingException {
+            return new Left<L, E>(cause);
+        }
+
+        @Override
+        protected Either<L, R> filterInternal(Condition<? super R> cond)
+                throws ExecutingException {
+            return new Left<L, R>(cause);
+        }
+
+        @Override
+        protected Either<L, R> filterInternal(Condition<? super R> cond, L left)
+                throws ExecutingException {
+            return new Left<L, R>(cause);
+        }
+
+        @Override
+        protected AttachAction<L> onRightInternal(Action<? super R> forRight) {
+            return new AttachAction<L>() {
+                @Override
+                protected ActingContext onLeftInternal(
+                        final Action<? super L> forLeft) {
+                    return new ActingContext() {
+                        @Override
+                        public void act() throws ExecutingException {
+                            forLeft.execute(cause);
+                        }
+                    };
+                }
+
+                @Override
+                public void act() throws ExecutingException {}
+            };
+        }
+    }
+
+    static class Right<L, R> extends Either<L, R> {
+
+        private final R value;
+
+        private final Lazy<L> gen;
+
+        Right(R value, Lazy<L> gen) {
+            shouldNotBeNull(value, "Right requires value.");
+            lazyShouldNotBeNull(gen);
+            this.value = value;
+            this.gen = gen;
+        }
+
+        @Override
+        public boolean isRight() {
+            return true;
+        }
+
+        @Override
+        public R get() throws NoSuchElementException {
+            return value;
+        }
+
+        @Override
+        protected R orInternal(R defaultValue) {
+            return value;
+        }
+
+        @Override
+        protected R orInternal(Lazy<? extends R> lazy)
+                throws ExecutingException {
+            return value;
+        }
+
+        @Override
+        protected R orThrowInternal(
+                Function<? super L, ? extends RuntimeException> fun)
+                throws RuntimeException {
+            return value;
+        }
+
+        private static <L> L take(Lazy<L> lazy) throws ExecutingException {
+            L left = lazy.get();
+            if (left == null) {
+                throw new ExecutingException("Default left value is null.");
+            }
+            return left;
+        }
+
+        @Override
+        protected <E> Either<L, E> mapInternal(
+                Function<? super R, ? extends E> fun)
+                throws ExecutingException {
+            E result = fun.apply(value);
+            if (result == null) {
+                return new Left<L, E>(take(gen));
+            } else  {
+                return new Right<L, E>(result, gen);
+            }
+        }
+
+        @Override
+        protected <E> Either<L, E> fmapInternal(
+                Function<? super R, ? extends Either<L, E>> fun)
+                throws ExecutingException {
+            Either<L, E> result = fun.apply(value);
+            if (result == null) {
+                return new Left<L, E>(take(gen));
+            } else {
+                return result;
+            }
+        }
+
+        @Override
+        protected Either<L, R> filterInternal(Condition<? super R> cond)
+                throws ExecutingException {
+            if (cond.test(value)) {
+                return new Right<L, R>(value, gen);
+            } else {
+                return new Left<L, R>(take(gen));
+            }
+        }
+
+        @Override
+        protected Either<L, R> filterInternal(Condition<? super R> cond, L left)
+                throws ExecutingException {
+            return cond.test(value) ?
+                    new Right<L, R>(value, gen) :
+                    new Left<L, R>(left);
+        }
+
+        @Override
+        protected AttachAction<L> onRightInternal(final Action<? super R> forRight) {
+            return new AttachAction<L>() {
+                @Override
+                protected ActingContext onLeftInternal(
+                        Action<? super L> forLeft) {
+                    return this;
+                }
+
+                @Override
+                public void act() throws ExecutingException {
+                    forRight.execute(value);
+                }
+            };
+        }
+    }
+}

--- a/g3-java-model/src/com.bsf.data/java/com/bsf/data/Maybe.java
+++ b/g3-java-model/src/com.bsf.data/java/com/bsf/data/Maybe.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2015 Shinya Mochida
+ *
+ * Licensed under the Apache License,Version2.0(the"License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,software
+ * Distributed under the License is distributed on an"AS IS"BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.bsf.data;
+
+import com.bsf.basic.EvaluationException;
+import com.bsf.basic.ExecutingException;
+
+import com.bsf.function.Actions.Action;
+import com.bsf.function.Conditions.Condition;
+import com.bsf.function.Functions.Function;
+import com.bsf.function.Lazies.Lazy;
+
+import com.bsf.data.MaybeBase.Nothing;
+import com.bsf.data.MaybeBase.Some;
+
+import java.util.NoSuchElementException;
+
+import static com.bsf.function.Verifications.actionShouldNotBeNull;
+import static com.bsf.function.Verifications.conditionShouldNotBeNull;
+import static com.bsf.function.Verifications.functionShouldNotBeNull;
+import static com.bsf.function.Verifications.lazyShouldNotBeNull;
+import static com.bsf.function.Verifications.shouldNotBeNull;
+
+public abstract class Maybe<V> {
+
+    // methods to retrieve value
+
+    abstract public V get() throws NoSuchElementException;
+
+    public V or(V defaultValue) throws EvaluationException {
+        shouldNotBeNull(defaultValue, "Default value is required.");
+        return orInternal(defaultValue);
+    }
+
+    abstract protected V orInternal(V defaultValue);
+
+    public V or(Lazy<V> lazy) throws EvaluationException, ExecutingException {
+        lazyShouldNotBeNull(lazy);
+        return orInternal(lazy);
+    }
+
+    abstract protected V orInternal(Lazy<V> lazy) throws ExecutingException;
+
+    public V orThrow(Lazy<? extends RuntimeException> lazyException) throws RuntimeException {
+        lazyShouldNotBeNull(lazyException);
+        return orThrowInternal(lazyException);
+    }
+
+    abstract protected V orThrowInternal(Lazy<? extends RuntimeException> lazyException)
+            throws RuntimeException;
+
+    // methods to mapping value to another type
+
+    public <R> Maybe<R> map(Function<? super V, ? extends R> fun)
+            throws EvaluationException, ExecutingException {
+        functionShouldNotBeNull(fun);
+        return mapInternal(fun);
+    }
+
+    abstract protected <R> Maybe<R> mapInternal(Function<? super V, ? extends R> fun)
+            throws ExecutingException;
+
+    public <R> Maybe<R> fmap(Function<? super V, ? extends Maybe<R>> fun)
+            throws EvaluationException, ExecutingException {
+        functionShouldNotBeNull(fun);
+        return fmapInternal(fun);
+    }
+
+    abstract protected <R> Maybe<R> fmapInternal(Function<? super V, ? extends Maybe<R>> fun)
+            throws ExecutingException;
+
+    // methods to filter value
+
+    public Maybe<V> filter(Condition<? super V> cond)
+            throws EvaluationException, ExecutingException {
+        conditionShouldNotBeNull(cond);
+        return filterInternal(cond);
+    }
+
+    abstract protected Maybe<V> filterInternal(Condition<? super V> cond)
+            throws ExecutingException;
+
+    // test whether holding value
+
+    public boolean isSome() {
+        return !isNothing();
+    }
+
+    abstract public boolean isNothing();
+
+    // attach action
+
+    public abstract class AttachAction implements ActingContext {
+
+        public ActingContext onNothing(Runnable forNothing) throws EvaluationException {
+            shouldNotBeNull(forNothing, "Default runnable should be non null.");
+            return onNothingInternal(forNothing);
+        }
+
+        abstract protected ActingContext onNothingInternal(Runnable forNothing);
+    }
+
+    public AttachAction onSome(Action<V> action) throws EvaluationException {
+        actionShouldNotBeNull(action);
+        return onSomeInternal(action);
+    }
+
+    abstract protected AttachAction onSomeInternal(Action<V> action);
+
+    // constructor
+
+    public static <T> Maybe<T> nothing() {
+        return new Nothing<T>();
+    }
+
+    public static <T> Maybe<T> some(T value) {
+        shouldNotBeNull(value, "Some can take non null value.");
+        return new Some<T>(value);
+    }
+
+    public static <T> Maybe<T> maybe(T value) {
+        if (value == null) {
+            return nothing();
+        } else {
+            return some(value);
+        }
+    }
+}

--- a/g3-java-model/src/com.bsf.data/java/com/bsf/data/MaybeBase.java
+++ b/g3-java-model/src/com.bsf.data/java/com/bsf/data/MaybeBase.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2015 Shinya Mochida
+ *
+ * Licensed under the Apache License,Version2.0(the"License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,software
+ * Distributed under the License is distributed on an"AS IS"BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.bsf.data;
+
+import com.bsf.basic.EvaluationException;
+import com.bsf.basic.ExecutingException;
+
+import com.bsf.function.Actions.Action;
+import com.bsf.function.Conditions.Condition;
+import com.bsf.function.Functions.Function;
+import com.bsf.function.Lazies.Lazy;
+
+import java.util.NoSuchElementException;
+
+import static com.bsf.function.Verifications.actionShouldNotBeNull;
+import static com.bsf.function.Verifications.conditionShouldNotBeNull;
+import static com.bsf.function.Verifications.functionShouldNotBeNull;
+import static com.bsf.function.Verifications.initializationNotSupported;
+import static com.bsf.function.Verifications.lazyShouldNotBeNull;
+import static com.bsf.function.Verifications.shouldNotBeNull;
+
+class MaybeBase {
+
+    private MaybeBase() {
+        initializationNotSupported();
+    }
+
+    static class Nothing<V> extends Maybe<V> {
+        @Override
+        public V get() throws NoSuchElementException {
+            throw new NoSuchElementException("Nothing has no element.");
+        }
+
+        @Override
+        protected V orInternal(V defaultValue) {
+            return defaultValue;
+        }
+
+        @Override
+        protected V orInternal(Lazy<V> lazy) throws ExecutingException {
+            return lazy.get();
+        }
+
+        @Override
+        protected V orThrowInternal(Lazy<? extends RuntimeException> lazyException) throws RuntimeException {
+            throw lazyException.get();
+        }
+
+        @Override
+        protected <R> Maybe<R> mapInternal(Function<? super V, ? extends R> fun) {
+            return new Nothing<R>();
+        }
+
+        @Override
+        protected <R> Maybe<R> fmapInternal(Function<? super V, ? extends Maybe<R>> fun) {
+            return new Nothing<R>();
+        }
+
+        @Override
+        protected Maybe<V> filterInternal(Condition<? super V> cond) {
+            return new Nothing<V>();
+        }
+
+        @Override
+        public boolean isNothing() {
+            return true;
+        }
+
+        @Override
+        protected AttachAction onSomeInternal(final Action<V> action) {
+            return new AttachAction() {
+                @Override
+                protected ActingContext onNothingInternal(final Runnable forNothing) {
+                    return new ActingContext() {
+                        @Override
+                        public void act() throws ExecutingException {
+                            forNothing.run();
+                        }
+                    };
+                }
+
+                @Override
+                public void act() throws ExecutingException {}
+            };
+        }
+
+        @Override
+        public String toString() {
+            return "Nothing";
+        }
+    }
+
+    static class Some<V> extends Maybe<V> {
+
+        private final V value;
+
+        Some(V value) {
+            this.value = value;
+        }
+
+        @Override
+        public V get() throws NoSuchElementException {
+            return value;
+        }
+
+        @Override
+        protected V orInternal(V defaultValue) {
+            return value;
+        }
+
+        @Override
+        protected V orInternal(Lazy<V> lazy) throws ExecutingException {
+            return value;
+        }
+
+        @Override
+        protected V orThrowInternal(Lazy<? extends RuntimeException> lazyException) throws RuntimeException {
+            return value;
+        }
+
+        @Override
+        protected  <R> Maybe<R> mapInternal(Function<? super V, ? extends R> fun)
+                throws ExecutingException {
+            R result = fun.apply(value);
+            return result == null ? new Nothing<R>() : new Some<R>(result);
+        }
+
+        @Override
+        protected  <R> Maybe<R> fmapInternal(
+                Function<? super V, ? extends Maybe<R>> fun)
+                throws ExecutingException {
+            Maybe<R> maybe = fun.apply(value);
+            return maybe == null ? new Nothing<R>() : maybe;
+        }
+
+        @Override
+        protected Maybe<V> filterInternal(Condition<? super V> cond)
+                throws ExecutingException{
+            return cond.test(value) ? new Some<V>(value) : new Nothing<V>();
+        }
+
+        @Override
+        public boolean isNothing() {
+            return false;
+        }
+
+        @Override
+        protected AttachAction onSomeInternal(final Action<V> action) {
+            return new AttachAction() {
+                @Override
+                protected ActingContext onNothingInternal(Runnable forNothing) {
+                    return this;
+                }
+
+                @Override
+                public void act() throws ExecutingException {
+                    action.execute(value);
+                }
+            };
+        }
+
+        @Override
+        public String toString() {
+            return "Some[" + value + "]";
+        }
+    }
+}

--- a/g3-java-model/src/com.bsf.data/java/com/bsf/data/Pair.java
+++ b/g3-java-model/src/com.bsf.data/java/com/bsf/data/Pair.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2015 Shinya Mochida
+ *
+ * Licensed under the Apache License,Version2.0(the"License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,software
+ * Distributed under the License is distributed on an"AS IS"BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.bsf.data;
+
+import com.bsf.basic.EvaluationException;
+import com.bsf.basic.ExecutingException;
+
+import com.bsf.function.Functions.Function;
+
+import static com.bsf.function.Verifications.shouldNotBeNull;
+
+public abstract class Pair<F, S> implements Function<Function<F, Function<S, Object>>, Object> {
+
+    public static <L, R> Pair<L, R> pair(final L first, final R second) throws EvaluationException {
+        shouldNotBeNull(first, "First element should be non null.");
+        shouldNotBeNull(second, "Second element should be non null.");
+        return new Pair<L, R>() {
+            @Override
+            public Object apply(Function<L, Function<R, Object>> function) throws ExecutingException {
+                return function.apply(first).apply(second);
+            }
+        };
+    }
+
+    @SuppressWarnings("unchecked")
+    public F fst() {
+        return (F)apply(new Function<F, Function<S, Object>>() {
+            @Override
+            public Function<S, Object> apply(final F f) throws ExecutingException {
+                return new Function<S, Object>() {
+                    @Override
+                    public Object apply(S s) throws ExecutingException {
+                        return f;
+                    }
+                };
+            }
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    public S snd() {
+        return (S)apply(new Function<F, Function<S, Object>>() {
+            @Override
+            public Function<S, Object> apply(F f) throws ExecutingException {
+                return new Function<S, Object>() {
+                    @Override
+                    public Object apply(S s) throws ExecutingException {
+                        return s;
+                    }
+                };
+            }
+        });
+    }
+
+    public Pair<S, F> swap() {
+        return pair(snd(), fst());
+    }
+}

--- a/g3-java-model/src/com.bsf.functions/java/com/bsf/function/Actions.java
+++ b/g3-java-model/src/com.bsf.functions/java/com/bsf/function/Actions.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2015 Shinya Mochida
+ *
+ * Licensed under the Apache License,Version2.0(the"License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,software
+ * Distributed under the License is distributed on an"AS IS"BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.bsf.function;
+
+import com.bsf.basic.EvaluationException;
+import com.bsf.basic.ExecutingException;
+
+import static com.bsf.function.Verifications.actionShouldNotBeNull;
+import static com.bsf.function.Verifications.initializationNotSupported;
+import static com.bsf.function.Verifications.shouldNotBeNull;
+
+public final class Actions {
+
+    private Actions() {
+        initializationNotSupported();
+    }
+
+    public interface ActionBase {}
+
+    public interface Action<I> extends ActionBase {
+        void execute(I input) throws ExecutingException;
+    }
+
+    public interface ExAction<I> extends ActionBase {
+        void execute(I input) throws Exception;
+    }
+
+    public static <I> Action<I> doAll(final Action<? super I> head, final Action<? super I>... actions) throws EvaluationException {
+        shouldNotBeNull(head, "Action should be non null value.");
+        for (Action<? super I> action : actions) {
+            actionShouldNotBeNull(action);
+        }
+        return new Action<I>() {
+            @Override
+            public void execute(I input) throws ExecutingException {
+                head.execute(input);
+                for (Action<? super I> action : actions) {
+                    action.execute(input);
+                }
+            }
+        };
+    }
+
+    public static <I> Action<I> action(final ExAction<? super I> exa) throws EvaluationException {
+        actionShouldNotBeNull(exa);
+        return new Action<I>() {
+            @Override
+            public void execute(I input) throws ExecutingException {
+                try {
+                    exa.execute(input);
+                } catch (Exception e) {
+                    throw new ExecutingException("Exception on executing ExAction.", e);
+                }
+            }
+        };
+    }
+}

--- a/g3-java-model/src/com.bsf.functions/java/com/bsf/function/Conditions.java
+++ b/g3-java-model/src/com.bsf.functions/java/com/bsf/function/Conditions.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2015 Shinya Mochida
+ *
+ * Licensed under the Apache License,Version2.0(the"License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,software
+ * Distributed under the License is distributed on an"AS IS"BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.bsf.function;
+
+import com.bsf.basic.EvaluationException;
+import com.bsf.basic.ExecutingException;
+
+import static com.bsf.function.Verifications.conditionShouldNotBeNull;
+import static com.bsf.function.Verifications.initializationNotSupported;
+
+public final class Conditions {
+
+    private Conditions() {
+        initializationNotSupported();
+    }
+
+    public interface ConditionBase {}
+
+    public interface Condition<S> extends ConditionBase {
+        boolean test(S subject) throws ExecutingException;
+    }
+
+    public interface ExCondition<S> extends ConditionBase {
+        boolean test(S subject) throws Exception;
+    }
+
+    public static <S> Condition<S> condition(final ExCondition<? super S> exc) {
+        conditionShouldNotBeNull(exc);
+        return new Condition<S>() {
+            @Override
+            public boolean test(S subject) throws ExecutingException {
+                try {
+                    return exc.test(subject);
+                } catch (Exception e) {
+                    throw new ExecutingException("Exception on testing of ExCondition.", e);
+                }
+            }
+        };
+    }
+
+    public static <S> Condition<S> all(final Condition<? super S> head,
+                                       final Condition<? super S>... tail)
+            throws EvaluationException{
+        conditionShouldNotBeNull(head);
+        return new Condition<S>() {
+            @Override
+            public boolean test(S subject) throws ExecutingException {
+                boolean result = head.test(subject);
+                if (tail == null || tail.length == 0) {
+                    return result;
+                } else {
+                    for (Condition<? super S> cond : tail) {
+                        result &= cond.test(subject);
+                        if (!result) {
+                            return false;
+                        }
+                    }
+                    return true;
+                }
+            }
+        };
+    }
+
+    public static <S> Condition<S> any(final Condition<? super S> head,
+                                       final Condition<? super S>... tail)
+            throws EvaluationException {
+        conditionShouldNotBeNull(head);
+        return new Condition<S>() {
+            @Override
+            public boolean test(S subject) throws ExecutingException {
+                boolean result = head.test(subject);
+                if (result || tail == null || tail.length == 0) {
+                    return result;
+                }
+                for (Condition<? super S> cond : tail) {
+                    if (cond.test(subject)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+        };
+    }
+}

--- a/g3-java-model/src/com.bsf.functions/java/com/bsf/function/Functions.java
+++ b/g3-java-model/src/com.bsf.functions/java/com/bsf/function/Functions.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015 Shinya Mochida
+ *
+ * Licensed under the Apache License,Version2.0(the"License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,software
+ * Distributed under the License is distributed on an"AS IS"BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.bsf.function;
+
+import com.bsf.basic.EvaluationException;
+import com.bsf.basic.ExecutingException;
+
+import static com.bsf.function.Verifications.functionShouldNotBeNull;
+import static com.bsf.function.Verifications.initializationNotSupported;
+
+public final class Functions {
+
+    private Functions() {
+        initializationNotSupported();
+    }
+
+    public interface FunctionBase {}
+
+    public interface Function<I, O> extends FunctionBase {
+        O apply(I input) throws ExecutingException;
+    }
+
+    public interface ExFunction<I, O> extends FunctionBase {
+        O apply(I input) throws Exception;
+    }
+
+    public static <I, O> Function<I, O> function(final ExFunction<? super I, ? extends O> fun) throws EvaluationException {
+        functionShouldNotBeNull(fun);
+        return new Function<I, O>() {
+            @Override
+            public O apply(I input) throws ExecutingException {
+                try {
+                    return fun.apply(input);
+                } catch (Exception e) {
+                    throw new ExecutingException("Exception on executing ExFunction.", e);
+                }
+            }
+        };
+    }
+}

--- a/g3-java-model/src/com.bsf.functions/java/com/bsf/function/Lazies.java
+++ b/g3-java-model/src/com.bsf.functions/java/com/bsf/function/Lazies.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015 Shinya Mochida
+ *
+ * Licensed under the Apache License,Version2.0(the"License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,software
+ * Distributed under the License is distributed on an"AS IS"BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.bsf.function;
+
+import com.bsf.basic.EvaluationException;
+import com.bsf.basic.ExecutingException;
+
+import static com.bsf.function.Verifications.initializationNotSupported;
+import static com.bsf.function.Verifications.lazyShouldNotBeNull;
+
+public final class Lazies {
+
+    private Lazies(){
+        initializationNotSupported();
+    }
+
+    public interface LazyBase {}
+
+    public interface Lazy<O> extends LazyBase {
+        O get() throws ExecutingException;
+    }
+
+    public interface ExLazy<O> extends LazyBase {
+        O get() throws Exception;
+    }
+
+    public static <O> Lazy<O> lazy(final ExLazy<? extends O> el) throws EvaluationException {
+        lazyShouldNotBeNull(el);
+        return new Lazy<O>() {
+            @Override
+            public O get() {
+                try {
+                    return el.get();
+                } catch (Exception e) {
+                    throw new ExecutingException("Exception on executing ExLazy.", e);
+                }
+            }
+        };
+    }
+}

--- a/g3-java-model/src/com.bsf.functions/java/com/bsf/function/Verifications.java
+++ b/g3-java-model/src/com.bsf.functions/java/com/bsf/function/Verifications.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2015 Shinya Mochida
+ *
+ * Licensed under the Apache License,Version2.0(the"License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,software
+ * Distributed under the License is distributed on an"AS IS"BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.bsf.function;
+
+import com.bsf.basic.EvaluationException;
+import com.bsf.basic.ExecutingException;
+
+import com.bsf.function.Actions.ActionBase;
+import com.bsf.function.Conditions.ConditionBase;
+import com.bsf.function.Functions.FunctionBase;
+import com.bsf.function.Lazies.LazyBase;
+
+public final class Verifications {
+
+    public static void initializationNotSupported()
+            throws UnsupportedOperationException {
+        throw new UnsupportedOperationException("To initialize this class " +
+                "is not supported");
+    }
+
+    private Verifications() throws UnsupportedOperationException {
+        initializationNotSupported();
+    }
+
+    public static void shouldNotBeNull(Object object, String message)
+            throws EvaluationException {
+        if (object == null) {
+            String msg = message == null || message.isEmpty() ?
+                    "Message undefined." : message;
+            throw new EvaluationException(msg);
+        }
+    }
+
+    public static void lazyShouldNotBeNull(LazyBase lazy) throws EvaluationException {
+        shouldNotBeNull(lazy, "Lazy should be non null value.");
+    }
+
+    public static void actionShouldNotBeNull(ActionBase action) throws EvaluationException {
+        shouldNotBeNull(action, "Action should be non null value.");
+    }
+
+    public static void functionShouldNotBeNull(FunctionBase function) throws EvaluationException {
+        shouldNotBeNull(function, "Function should be non null value.");
+    }
+
+    public static void conditionShouldNotBeNull(ConditionBase condition) throws EvaluationException {
+        shouldNotBeNull(condition, "Condition should be non null value.");
+    }
+}


### PR DESCRIPTION
Create JVM component model project, via https://docs.gradle.org/current/userguide/building_java_libraries.html

I think this model is preparation for Java9 Project Jigsaw.
- Constraints for module visibility are more severe than I expected.
  - It is needed to declare for each module to refer another module.
  - transitive dependency is not applied.
- Expecting
  - With JVM component model with platform `java9` Gradle generates `module-info.java`, with additional DSL extension.
