### PR TITLE
find component name bug

### DIFF
--- a/component-name/build.gradle
+++ b/component-name/build.gradle
@@ -7,5 +7,6 @@ model {
     components {
         '.'(JvmLibrarySpec)
         '..'(JvmLibrarySpec)
+        '../src'(JvmLibrarySpec)
     }
 }

--- a/component-name/build.gradle
+++ b/component-name/build.gradle
@@ -6,5 +6,6 @@ plugins {
 model {
     components {
         '.'(JvmLibrarySpec)
+        '..'(JvmLibrarySpec)
     }
 }

--- a/component-name/java/com/test/Main.java
+++ b/component-name/java/com/test/Main.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2015 Shinya Mochida
+ *
+ * Licensed under the Apache License,Version2.0(the"License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,software
+ * Distributed under the License is distributed on an"AS IS"BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.test;
+
+import java.io.*;
+import java.util.stream.*;
+
+public class Main implements Runnable {
+
+    public static void main(String... args) {
+        new Main().run();
+    }
+
+    private final ClassLoader loader = getClass().getClassLoader();
+
+    Main() {}
+
+    @Override
+    public void run() {
+        try(Stream<String> st = new BufferedReader(new InputStreamReader(loader.getResourceAsStream("test.txt"))).lines()) {
+            st.forEach(System.out::println);
+        }
+    }
+}

--- a/component-name/resources/test.txt
+++ b/component-name/resources/test.txt
@@ -1,0 +1,1 @@
+This is test text.

--- a/component-name/src/java/com/test/Main.java
+++ b/component-name/src/java/com/test/Main.java
@@ -31,7 +31,7 @@ public class Main implements Runnable {
 
     @Override
     public void run() {
-        try(Stream st = new BufferedReader(new InputStreamReader(loader.getResourceAsStream("test.txt"))).lines()) {
+        try(Stream<String> st = new BufferedReader(new InputStreamReader(loader.getResourceAsStream("test.txt"))).lines()) {
             st.forEach(System.out::println);
         }
     }


### PR DESCRIPTION
If library name is `../src`, build will fail.

```
$ gradle build
:compile../srcJar../srcJava FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':compile../srcJar../srcJava'.
> ディレクトリがありません: /path/to/project/build/classes/../srcJar

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED

Total time: 0.761 secs
```
